### PR TITLE
avoid issue with '-std=c++17' on mac osx

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -63,7 +63,10 @@ def cpp_flag(compiler):
     """Return the -std=c++[11/14/17] compiler flag.
     The newer version is prefered over c++11 (when it is available).
     """
-    flags = ['-std=c++17', '-std=c++14', '-std=c++11']
+    if sys.platform == 'darwin':
+        flags = ['-std=c++14', '-std=c++11']
+    else:
+        flags = ['-std=c++17', '-std=c++14', '-std=c++11']
 
     for flag in flags:
         if has_flag(compiler, flag): return flag


### PR DESCRIPTION
Hi @mirca, when trying to install `riskparity.py` on my mac, it crashed throwing the same error related to `rlang` and `pybind11` outlined here: https://github.com/pybind/pybind11/issues/1604 
and here: https://www.bountysource.com/issues/77010193-macos-std-c-17-requires-mmacosx-version-min-10-14 

I got the `riskparity.py` installation working with the code in this PR which ignores the `'-std=c++17'` flag if it's a mac 

